### PR TITLE
Fix for extensive sweep not testing all combinations.

### DIFF
--- a/factorio_balancers/balancer.py
+++ b/factorio_balancers/balancer.py
@@ -498,7 +498,7 @@ class Balancer(Blueprint):
         if extensive:
             i_range = range(
                 1,
-                min(
+                1 + min(
                     len(self._input_belts),
                     len(self._output_belts)))
             nr_of_permutations = get_nr_of_permutations(


### PR DESCRIPTION
The set i_range should be inclusive of the min of the number of input or output belts, since the range function is not inclusive, 1 must be added to the upper value.